### PR TITLE
apply mattcen's patches from v189

### DIFF
--- a/alloccli/alloc.py
+++ b/alloccli/alloc.py
@@ -412,7 +412,7 @@ class alloc(object):
         # empty string.
         r = defaultdict(str)
         for a, b in row.items():
-            r[a] = str(b or '')
+            r[a] = b or ''
         return r
 
     def print_task(self, taskID, prependEmailHeader=False, children=False):

--- a/alloccli/alloc.py
+++ b/alloccli/alloc.py
@@ -720,8 +720,7 @@ class alloc(object):
     def dbg(self, s):
         # Print a message to the screen (stdout) for debugging only.
         if self.debug:
-            print "DBG " + str(s)
-            sys.stdout.flush()
+            sys.stderr.write("DBG " + str(s) + '\n')
 
     def parse_email(self, email):
         # Parse an email address from this: Jon Smit <js@example.com> into:

--- a/alloccli/alloc_output_handler.py
+++ b/alloccli/alloc_output_handler.py
@@ -190,6 +190,10 @@ class alloc_output_handler:
 
         if alloc.csv:
             csv_table = csv.writer(sys.stdout, lineterminator="\n")
+            # FIXME: This shows the header for the CSV. It should have a CLI
+            # option to turn it on, but for now, just print it always and let
+            # the user filter it out if necessary.
+            csv_table.writerow([unicode(s).encode('utf-8') for s in field_names])
             for row in rows:
                 csv_table.writerow([unicode(s).encode('utf-8') for s in row])
 


### PR DESCRIPTION
This applies 3 of mattcen's patches from the [v189](https://github.com/cyberitsolutions/alloc/tree/v189) branch:

* https://github.com/cyberitsolutions/alloc/commit/0941ca235e50b984d0f83379a82eef66fc2c3971
* https://github.com/cyberitsolutions/alloc/commit/4d4b930713c2ec05595592a754c6ab744929ee4d
* https://github.com/cyberitsolutions/alloc/commit/22a8708650aadafff5fe2dbce0982956da530e15

The patch https://github.com/cyberitsolutions/alloc/commit/6a6dbb0ec039514664a46873d1edd9c4778b98b8 isn't here because alloccli was restructured, and then support for showing tags was added in 9da0cc2355e9195610ba188c23fa54ef44b153d8 (I can't believe I used to add features in something like a code style tidy up 👀😞😑)