### PR TITLE
from 2 -> 3: print to print()

### DIFF
--- a/alloccli/accounts.py
+++ b/alloccli/accounts.py
@@ -1,6 +1,6 @@
 """alloccli subcommand for TF accounts."""
+from __future__ import print_function
 from alloc import alloc
-
 
 class accounts(alloc):
 
@@ -53,7 +53,7 @@ class accounts(alloc):
             if transactions:
                 self.print_table(
                     "transaction", transactions, fields, "transactionDate")
-                print "num rows:", len(transactions)
+                print("num rows:", len(transactions))
 
         # Get tf (tagged fund)
         else:

--- a/alloccli/alloc.py
+++ b/alloccli/alloc.py
@@ -1,4 +1,5 @@
 """alloc library"""
+from __future__ import print_function
 import os
 import sys
 import simplejson
@@ -682,13 +683,13 @@ class alloc(object):
     def msg(self, s):
         """Print a message to the screen (stdout)."""
         if not self.quiet:
-            print "--- " + str(s)
+            print("--- " + str(s))
             sys.stdout.flush()
 
     def yay(self, s):
         """Print a success message to the screen (stdout)."""
         if not self.quiet:
-            print ":-] " + str(s)
+            print(":-] " + str(s))
             sys.stdout.flush()
 
     def err(self, s):

--- a/alloccli/alloc_cli_arg_handler.py
+++ b/alloccli/alloc_cli_arg_handler.py
@@ -1,4 +1,5 @@
 # alloc library for handling command line arguments.
+from __future__ import print_function
 import os
 import sys
 import re
@@ -125,13 +126,13 @@ class alloc_cli_arg_handler:
 
         # If --help print help and die
         if rtn['help']:
-            print self.get_subcommand_help(command_list, ops, s)
+            print(self.get_subcommand_help(command_list, ops, s))
             sys.exit(0)
 
         # If --list-option print options and die
         if 'list-option' in rtn and rtn['list-option']:
             for opt in all_ops_list:
-                print opt
+                print(opt)
             sys.exit(0)
 
         # If --csv tell the alloc object about it

--- a/alloccli/alloc_output_handler.py
+++ b/alloccli/alloc_output_handler.py
@@ -1,4 +1,5 @@
 # alloc library for outputting ascii or csv tables
+from __future__ import print_function
 import sys
 import re
 import csv
@@ -217,7 +218,7 @@ class alloc_output_handler:
                         alloc, rows, field_names, width)
             for row in rows:
                 table.add_row(row)
-            print unicode(table.get_string(header=True)).encode('utf-8')
+            print(unicode(table.get_string(header=True)).encode('utf-8'))
             # http://stackoverflow.com/questions/15793886/how-to-avoid-a-broken-pipe-error-when-printing-a-large-amount-of-formatted-data
             sys.stdout.flush()
 

--- a/alloccli/browse.py
+++ b/alloccli/browse.py
@@ -1,4 +1,5 @@
 """alloccli subcommand for launching your $BROWSER at alloc."""
+from __future__ import print_function
 import os
 from sys import stdout
 from alloc import alloc
@@ -94,7 +95,7 @@ alloc browse --time 213'''
 
         # If we're redirecting stdout eg -t 123 >task123.html
         if not stdout.isatty():
-            print self.get_alloc_html(url)
+            print(self.get_alloc_html(url))
 
         elif url:
             browser = ''

--- a/alloccli/mbox.py
+++ b/alloccli/mbox.py
@@ -71,7 +71,7 @@ alloc mbox -t 1234 > file.mbox'''
 
             # If we're redirecting stdout eg alloc mbox -t 123 >task123.html
             if not stdout.isatty():
-                print unicode(s).encode('utf-8')
+                print(unicode(s).encode('utf-8'))
 
             else:
                 try:

--- a/alloccli/view.py
+++ b/alloccli/view.py
@@ -1,6 +1,6 @@
 """alloccli subcommand for viewing the details of a single entity."""
+from __future__ import print_function
 from alloc import alloc
-
 
 class view(alloc):
 
@@ -35,4 +35,4 @@ alloc view --task 1234"""
         self.authenticate()
 
         if o['task']:
-            print self.print_task(o['task'], children=o['children'])
+            print(self.print_task(o['task'], children=o['children']))


### PR DESCRIPTION
This is just the print function, and uses `from __future__ import print_function` to work under python2.

I figure if I do one small step towards python3 every so often alloc-cli might just run with python3 before the deadline 😂