### PR TITLE
convert the README to ReST

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
-# alloc-cli
+alloc-cli
+=========
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/97940338acbe4f709717d431d75c478a)](https://www.codacy.com/app/cjbayliss/alloc-cli?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cyberitsolutions/alloc-cli&amp;utm_campaign=Badge_Grade)
-
-## A CLI that uses alloc's API
+A CLI that uses alloc’s API
+---------------------------
 
 The most commonly used interface for allocPSA is the web interface, which is
 accessible from your web browser. Additionally there is an email interface that
@@ -11,18 +11,24 @@ specific keywords in the subject line.
 
 Finally, there is also a command line interface for alloc, alloc-cli.
 
-## Usage
+Usage
+-----
 
 alloc-cli can be invoked by running:
 
-`./alloc <option-here>`
+::
+
+   ./alloc <option-here>
 
 For a list of options, run:
 
-`./alloc --help`
+::
 
-## License
+   ./alloc --help``
+
+License
+-------
 
 alloc-cli is under the GNU Affero General Public License. For more info please
-see the LICENSE file or visit the [GNU Affero General Public
-License](http://www.gnu.org/licenses/agpl-3.0.en.html) webpage.
+see the LICENSE file or visit the `GNU Affero General Public License
+<http://www.gnu.org/licenses/agpl-3.0.en.html>`__ webpage.


### PR DESCRIPTION
This seems like the right thing to do because ReStructuredText is the prefered docment format for python projects.

I removed the Codacy badge because it was broken.